### PR TITLE
Workflow for creating and publishing nugets to GitHub Packages upon creating releases in main

### DIFF
--- a/.github/workflows/ci-nuget.yml
+++ b/.github/workflows/ci-nuget.yml
@@ -13,9 +13,10 @@ jobs:
       uses: actions/checkout@v2
     - name: Set VERSION variable from latest tag (if existing) plus date and commit
       run: | 
+        git fetch --all --tags
         LATEST_TAG=$((git describe --tags --abbrev=0 | sed s/^v//) 2>/dev/null)
         LATEST_TAG=${LATEST_TAG:=0.0.1}
-        VERSION=${LATEST_TAG}-prerelease.$(date +%Y%m%d)+${GITHUB_SHA:0:5}
+        VERSION=${LATEST_TAG}-prerelease.$(date +%Y%m%d).${GITHUB_SHA:0:5}
         echo "VERSION: ${VERSION}" 
         echo "VERSION=${VERSION}" >> $GITHUB_ENV
     - name: Set SOLUTION variable to point to solution file

--- a/.github/workflows/ci-nuget.yml
+++ b/.github/workflows/ci-nuget.yml
@@ -28,8 +28,8 @@ jobs:
       run: dotnet build --configuration Release /p:Version=${VERSION} ${SOLUTION}
     - name: Test
       run: dotnet test --configuration Release /p:Version=${VERSION} --no-build ${SOLUTION}
-    - name: Pack
-      run: dotnet pack --configuration Release /p:Version=${VERSION} --no-build --output . ${SOLUTION}
+    - name: Pack with debug symbols
+      run: dotnet pack --configuration Release /p:Version=${VERSION} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg --output . ${SOLUTION}
     - name: Push
       run: dotnet nuget push *.${VERSION}.nupkg --source https://nuget.pkg.github.com/${GITHUB_ACTOR}/index.json --api-key ${GITHUB_TOKEN}
       env:

--- a/.github/workflows/ci-nuget.yml
+++ b/.github/workflows/ci-nuget.yml
@@ -14,7 +14,8 @@ jobs:
     - name: Set VERSION variable from latest tag (if existing) plus date and commit
       run: | 
         git fetch --all --tags
-        LATEST_TAG=$((git describe --tags --abbrev=0 | sed s/^v//) 2>/dev/null)
+        LATEST_TAG=$(git describe --tags --abbrev=0 | sed s/^v//)
+        echo "LATEST_TAG: ${LATEST_TAG}"
         LATEST_TAG=${LATEST_TAG:=0.0.1}
         VERSION=${LATEST_TAG}-next.$(date +%Y%m%d).${GITHUB_RUN_NUMBER}
         echo "VERSION: ${VERSION}" 

--- a/.github/workflows/ci-nuget.yml
+++ b/.github/workflows/ci-nuget.yml
@@ -1,0 +1,33 @@
+name: CI Nuget
+
+on:
+  push:
+    branches:
+    - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set VERSION variable from latest tag (if existing) plus date and commit
+      run:  
+        LATEST_TAG=$((git describe --tags --abbrev=0 | sed s/^v//) 2>/dev/null)
+        LATEST_TAG=${LATEST_TAG:=0.0.1}
+        VERSION=${LATEST_TAG}-prerelease.$(date +%Y%m%d)+${GITHUB_SHA:0:5}
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+    - name: Set SOLUTION variable to point to solution file
+      run: |
+        SOLUTION=$(find . -name '*.sln' -printf "%p" -quit)
+        echo "SOLUTION=${SOLUTION}" >> $GITHUB_ENV
+    - name: Build
+      run: dotnet build --configuration Release /p:Version=${VERSION} ${SOLUTION}
+    - name: Test
+      run: dotnet test --configuration Release /p:Version=${VERSION} --no-build ${SOLUTION}
+    - name: Pack
+      run: dotnet pack --configuration Release /p:Version=${VERSION} --no-build --output . ${SOLUTION}
+    - name: Push
+      run: dotnet nuget push *.${VERSION}.nupkg --source https://nuget.pkg.github.com/${GITHUB_ACTOR}/index.json --api-key ${GITHUB_TOKEN}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-nuget.yml
+++ b/.github/workflows/ci-nuget.yml
@@ -12,14 +12,16 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Set VERSION variable from latest tag (if existing) plus date and commit
-      run:  
+      run: | 
         LATEST_TAG=$((git describe --tags --abbrev=0 | sed s/^v//) 2>/dev/null)
         LATEST_TAG=${LATEST_TAG:=0.0.1}
         VERSION=${LATEST_TAG}-prerelease.$(date +%Y%m%d)+${GITHUB_SHA:0:5}
+        echo "VERSION: ${VERSION}" 
         echo "VERSION=${VERSION}" >> $GITHUB_ENV
     - name: Set SOLUTION variable to point to solution file
       run: |
         SOLUTION=$(find . -name '*.sln' -printf "%p" -quit)
+        echo "SOLUTION: ${SOLUTION}"
         echo "SOLUTION=${SOLUTION}" >> $GITHUB_ENV
     - name: Build
       run: dotnet build --configuration Release /p:Version=${VERSION} ${SOLUTION}

--- a/.github/workflows/ci-nuget.yml
+++ b/.github/workflows/ci-nuget.yml
@@ -16,7 +16,7 @@ jobs:
         git fetch --all --tags
         LATEST_TAG=$((git describe --tags --abbrev=0 | sed s/^v//) 2>/dev/null)
         LATEST_TAG=${LATEST_TAG:=0.0.1}
-        VERSION=${LATEST_TAG}-prerelease.$(date +%Y%m%d).${GITHUB_SHA:0:5}
+        VERSION=${LATEST_TAG}-next.$(date +%Y%m%d).${GITHUB_RUN_NUMBER}
         echo "VERSION: ${VERSION}" 
         echo "VERSION=${VERSION}" >> $GITHUB_ENV
     - name: Set SOLUTION variable to point to solution file

--- a/.github/workflows/ci-nuget.yml
+++ b/.github/workflows/ci-nuget.yml
@@ -13,8 +13,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Set VERSION variable from latest tag (if existing) plus date and commit
       run: | 
-        git fetch --all --tags
-        LATEST_TAG=$(git describe --tags --abbrev=0 | sed s/^v//)
+        LATEST_TAG=$(git ls-remote --tags origin | tail -n 1 | awk '{ print $2; }' | sed 's/.*v//')
         echo "LATEST_TAG: ${LATEST_TAG}"
         LATEST_TAG=${LATEST_TAG:=0.0.1}
         VERSION=${LATEST_TAG}-next.$(date +%Y%m%d).${GITHUB_RUN_NUMBER}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,12 +18,14 @@ jobs:
         git branch --remote --contains | grep origin/main
     - name: Set VERSION variable from tag
       run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
+    - name: Set SOLUTION variable to point to solution file
+      run: echo "SOLUTION=src/Altinn.ApiClients.Maskinporten/Altinn.ApiClients.Maskinporten.sln" >> $GITHUB_ENV
     - name: Build
-      run: dotnet build --configuration Release /p:Version=${VERSION}
+      run: dotnet build --configuration Release /p:Version=${VERSION} ${SOLUTION}
     - name: Test
-      run: dotnet test --configuration Release /p:Version=${VERSION} --no-build
+      run: dotnet test --configuration Release /p:Version=${VERSION} --no-build ${SOLUTION}
     - name: Pack
-      run: dotnet pack --configuration Release /p:Version=${VERSION} --no-build --output .
+      run: dotnet pack --configuration Release /p:Version=${VERSION} --no-build --output . ${SOLUTION}
     - name: Push
       run: dotnet nuget push Altinn.ApiClients.Maskinporten.${VERSION}.nupkg --source https://nuget.pkg.github.com/elsand/index.json --api-key ${GITHUB_TOKEN}
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,30 @@
+# Workflow creating a Github package
+name: Release
+
+on:
+  push:
+    tags:
+    - "v[0-9]+.[0-9]+.[0-9]+"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Verify commit exists in origin/main
+      run: |
+        git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+        git branch --remote --contains | grep origin/main
+    - name: Set VERSION variable from tag
+      run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
+    - name: Build
+      run: dotnet build --configuration Release /p:Version=${VERSION}
+    - name: Test
+      run: dotnet test --configuration Release /p:Version=${VERSION} --no-build
+    - name: Pack
+      run: dotnet pack --configuration Release /p:Version=${VERSION} --no-build --output .
+    - name: Push
+      run: dotnet nuget push Altinn.ApiClients.Maskinporten.${VERSION}.nupkg --source https://nuget.pkg.github.com/elsand/index.json --api-key ${GITHUB_TOKEN}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -29,6 +29,6 @@ jobs:
     - name: Pack
       run: dotnet pack --configuration Release /p:Version=${VERSION} --no-build --output . ${SOLUTION}
     - name: Push
-      run: dotnet nuget push Altinn.ApiClients.Maskinporten.${VERSION}.nupkg --source https://nuget.pkg.github.com/${GITHUB_ACTOR}/index.json --api-key ${GITHUB_TOKEN}
+      run: dotnet nuget push *.${VERSION}.nupkg --source https://nuget.pkg.github.com/${GITHUB_ACTOR}/index.json --api-key ${GITHUB_TOKEN}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -1,5 +1,5 @@
 # Workflow creating a Github package
-name: Release
+name: Release Nuget
 
 on:
   push:
@@ -19,7 +19,9 @@ jobs:
     - name: Set VERSION variable from tag
       run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
     - name: Set SOLUTION variable to point to solution file
-      run: echo "SOLUTION=src/Altinn.ApiClients.Maskinporten/Altinn.ApiClients.Maskinporten.sln" >> $GITHUB_ENV
+      run: |
+        SOLUTION=$(find . -name '*.sln' -printf "%p" -quit)
+        echo "SOLUTION=${SOLUTION}" >> $GITHUB_ENV
     - name: Build
       run: dotnet build --configuration Release /p:Version=${VERSION} ${SOLUTION}
     - name: Test
@@ -27,6 +29,6 @@ jobs:
     - name: Pack
       run: dotnet pack --configuration Release /p:Version=${VERSION} --no-build --output . ${SOLUTION}
     - name: Push
-      run: dotnet nuget push Altinn.ApiClients.Maskinporten.${VERSION}.nupkg --source https://nuget.pkg.github.com/elsand/index.json --api-key ${GITHUB_TOKEN}
+      run: dotnet nuget push Altinn.ApiClients.Maskinporten.${VERSION}.nupkg --source https://nuget.pkg.github.com/${GITHUB_ACTOR}/index.json --api-key ${GITHUB_TOKEN}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+    - name: Verify that NUGET_ORG_API_KEY is set
+      run: test -z ${{ secrets.NUGET_ORG_API_KEY }}
     - name: Checkout
       uses: actions/checkout@v2
     - name: Verify commit exists in origin/main
@@ -28,7 +30,7 @@ jobs:
       run: dotnet test --configuration Release /p:Version=${VERSION} --no-build ${SOLUTION}
     - name: Pack with debug symbols
       run: dotnet pack --configuration Release /p:Version=${VERSION} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg --output . ${SOLUTION}
-    - name: Push
-      run: dotnet nuget push *.${VERSION}.nupkg --source https://nuget.pkg.github.com/${GITHUB_ACTOR}/index.json --api-key ${GITHUB_TOKEN}
+    - name: Push to nuget.org
+      run: dotnet nuget push *.${VERSION}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_ORG_API_KEY }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -26,8 +26,8 @@ jobs:
       run: dotnet build --configuration Release /p:Version=${VERSION} ${SOLUTION}
     - name: Test
       run: dotnet test --configuration Release /p:Version=${VERSION} --no-build ${SOLUTION}
-    - name: Pack
-      run: dotnet pack --configuration Release /p:Version=${VERSION} --no-build --output . ${SOLUTION}
+    - name: Pack with debug symbols
+      run: dotnet pack --configuration Release /p:Version=${VERSION} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg --output . ${SOLUTION}
     - name: Push
       run: dotnet nuget push *.${VERSION}.nupkg --source https://nuget.pkg.github.com/${GITHUB_ACTOR}/index.json --api-key ${GITHUB_TOKEN}
       env:

--- a/src/Altinn.ApiClients.Maskinporten/Altinn.ApiClients.Maskinporten.csproj
+++ b/src/Altinn.ApiClients.Maskinporten/Altinn.ApiClients.Maskinporten.csproj
@@ -2,9 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <Version>0.9.62-alpha</Version>
+    <Version>1.0.0</Version>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PackageId>Altinn.ApiClients.Maskinporten</PackageId>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/elsand/altinn-apiclient-maskinporten</RepositoryUrl>
+  </PropertyGroup>
+   
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
@@ -12,5 +18,5 @@
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.11.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.11.1" />
   </ItemGroup>
-
+   
 </Project>

--- a/src/Altinn.ApiClients.Maskinporten/Altinn.ApiClients.Maskinporten.csproj
+++ b/src/Altinn.ApiClients.Maskinporten/Altinn.ApiClients.Maskinporten.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <PackageId>Altinn.ApiClients.Maskinporten</PackageId>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/elsand/altinn-apiclient-maskinporten</RepositoryUrl>
+    <RepositoryUrl>https://github.com/Altinn/altinn-apiclient-maskinporten</RepositoryUrl>
   </PropertyGroup>
    
   <ItemGroup>

--- a/src/Altinn.ApiClients.Maskinporten/Altinn.ApiClients.Maskinporten.csproj
+++ b/src/Altinn.ApiClients.Maskinporten/Altinn.ApiClients.Maskinporten.csproj
@@ -2,11 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <Version>1.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>
     <PackageId>Altinn.ApiClients.Maskinporten</PackageId>
+    <Company>Digitaliseringsdirektoratet</Company>
+    <PackageTags>digdir;altinn;maskinporten</PackageTags>
+    <Description>
+      This library is used for integrating with HTTP APIs secured with Maskinporten, transparently obtaining access tokens based on configured values
+    </Description>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Altinn/altinn-apiclient-maskinporten</RepositoryUrl>
   </PropertyGroup>

--- a/src/Altinn.ApiClients.Maskinporten/Altinn.ApiClients.Maskinporten.csproj
+++ b/src/Altinn.ApiClients.Maskinporten/Altinn.ApiClients.Maskinporten.csproj
@@ -18,5 +18,5 @@
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.11.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.11.1" />
   </ItemGroup>
-   
+
 </Project>


### PR DESCRIPTION
This is a workflow loosely based on https://acraven.medium.com/a-nuget-package-workflow-using-github-actions-7da8c6557863 that builds/packages and publishes a nuget in Github Packages upon creating a release (remote tag) from the main-branch having a semver-format (eg. v12.3.13). 

Attempts have been made to keep the workflow generic, ie. it can be copied into other repositories without requiring change. Note however that a propertygroup in each .csproj is required describing the name of the package. (The version-property is overridden in the call to `dotnet pack`)

Note that for repositories with multiple solutions (.sln), this will build the first one it finds.