### PR TITLE
Add token cache provider implementation

### DIFF
--- a/samples/SampleWebApp/Controllers/MaskinportenTestController.cs
+++ b/samples/SampleWebApp/Controllers/MaskinportenTestController.cs
@@ -36,7 +36,6 @@ namespace SampleWebApp.Controllers
             var result2 = await _myMaskinportenHttpClient.PerformStuff(url);
 
             return "Done!";
-
         }
     }
 }

--- a/samples/SampleWebApp/Controllers/MaskinportenTestController.cs
+++ b/samples/SampleWebApp/Controllers/MaskinportenTestController.cs
@@ -35,7 +35,7 @@ namespace SampleWebApp.Controllers
             var result1 = await client1.GetAsync(url);
             var result2 = await _myMaskinportenHttpClient.PerformStuff(url);
 
-            return "Done";
+            return "Done!";
 
         }
     }

--- a/samples/SampleWebApp/Startup.cs
+++ b/samples/SampleWebApp/Startup.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -26,7 +27,18 @@ namespace SampleWebApp
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddControllers();
-            
+
+            // Explicitly add a file based token cache store. You could add your own by implementing ITokenCacheProvider.
+            // This will place a file called ".maskinportenTokenCache.json" in the users temp-folder. This will NOT be deleted
+            // after application termination. This makes it suitable for CLI usage.
+            // 
+            // If no token cache store is added before the first AddMaskinportenHttpClient-call, a MemoryCache-based cache store
+            // will be used.
+
+            services.AddSingleton<ITokenCacheProvider, FileTokenCacheProvider>();
+            // Alternatively, one can supply a file path. This will be created or overwritten.
+            // services.AddSingleton<ITokenCacheProvider>(new FileTokenCacheProvider("c:/temp/mycachestore.json"));
+
             // Add a named client
             services.AddMaskinportenHttpClient<Pkcs12ClientDefinition>(
                 Configuration.GetSection("MyMaskinportenSettingsForCertFile"), 

--- a/src/Altinn.ApiClients.Maskinporten/Config/MaskinportenSettings.cs
+++ b/src/Altinn.ApiClients.Maskinporten/Config/MaskinportenSettings.cs
@@ -5,17 +5,17 @@ namespace Altinn.ApiClients.Maskinporten.Config
     public class MaskinportenSettings
     {
         /// <summary>
-        /// ClientID if fixed
+        /// ClientID to use
         /// </summary>
         public string ClientId { get; set; }
 
         /// <summary>
-        /// Scope if fixed
+        /// Scopes to request. Must be provisioned on the supplied client.
         /// </summary>
         public string Scope { get; set; }
 
         /// <summary>
-        /// Resource if fixed
+        /// Resource claim for assertion. This will be the `aud`-claim in the received access token
         /// </summary>
         public string Resource { get; set; }
 

--- a/src/Altinn.ApiClients.Maskinporten/Interfaces/ITokenCacheProvider.cs
+++ b/src/Altinn.ApiClients.Maskinporten/Interfaces/ITokenCacheProvider.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Threading.Tasks;
+using Altinn.ApiClients.Maskinporten.Models;
+
+namespace Altinn.ApiClients.Maskinporten.Interfaces
+{
+    public interface ITokenCacheProvider
+    {
+        public Task<(bool success, TokenResponse result)> TryGetToken(string key);
+        public Task Set(string key, TokenResponse value, TimeSpan timeToLive);
+    }
+}

--- a/src/Altinn.ApiClients.Maskinporten/Services/FileTokenCacheProvider.cs
+++ b/src/Altinn.ApiClients.Maskinporten/Services/FileTokenCacheProvider.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Altinn.ApiClients.Maskinporten.Interfaces;
+using Altinn.ApiClients.Maskinporten.Models;
+
+namespace Altinn.ApiClients.Maskinporten.Services
+{
+    public class FileTokenCacheProvider : ITokenCacheProvider
+    {
+        private readonly string _pathToCacheFile;
+        private static Dictionary<string, TokenCacheStoreEntry> _tokenCacheStoreEntries = new();
+
+        public FileTokenCacheProvider(string pathToCacheFile)
+        {
+            _pathToCacheFile = pathToCacheFile;
+        }
+
+        public FileTokenCacheProvider() : this(Path.GetTempPath() + ".maskinportenTokenCache.json") {}
+        
+        public async Task<(bool success, TokenResponse result)> TryGetToken(string key)
+        {
+            if (_tokenCacheStoreEntries.Count == 0)
+            {
+                await LoadTokenCacheStore();
+            }
+
+            if (_tokenCacheStoreEntries.TryGetValue(key, out TokenCacheStoreEntry cachedTokenEntry))
+            {
+                if (cachedTokenEntry.Expires > DateTime.UtcNow)
+                {
+                    return (true, cachedTokenEntry.TokenResponse);
+                }
+            }
+
+            return (false, null);
+        }
+
+        public async Task Set(string key, TokenResponse value, TimeSpan timeToLive)
+        {
+            _tokenCacheStoreEntries[key] = new TokenCacheStoreEntry
+            {
+                TokenResponse = value,
+                Expires = DateTime.UtcNow.Add(timeToLive)
+            };
+
+            await WriteTokenCacheStore();
+        }
+
+        private async Task LoadTokenCacheStore()
+        {
+            byte[] fileContents;
+            await using (FileStream fs = File.Open(_pathToCacheFile, FileMode.OpenOrCreate, FileAccess.ReadWrite))
+            {
+                if (fs.Length == 0)
+                {
+                    return;
+                }
+
+                fileContents = new byte[fs.Length];
+                await fs.ReadAsync(fileContents.AsMemory(0, (int)fs.Length));
+            }
+
+            _tokenCacheStoreEntries = JsonSerializer.Deserialize<Dictionary<string, TokenCacheStoreEntry>>(fileContents);
+        }
+
+        private async Task WriteTokenCacheStore()
+        {
+            // Remove all expired entries before writing
+            foreach (var tokenCacheStoreEntry in 
+                     _tokenCacheStoreEntries.Where(tokenCacheStoreEntry => tokenCacheStoreEntry.Value.Expires < DateTime.UtcNow))
+            {
+                _tokenCacheStoreEntries.Remove(tokenCacheStoreEntry.Key);
+            }
+
+            await using FileStream fs = File.Open(_pathToCacheFile, FileMode.OpenOrCreate, FileAccess.ReadWrite);
+            fs.SetLength(0);
+            await fs.WriteAsync(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(_tokenCacheStoreEntries)));
+            await fs.FlushAsync();
+        }
+    }
+
+    internal class TokenCacheStoreEntry
+    {
+        public TokenResponse TokenResponse;
+        public DateTime Expires;
+    }
+}

--- a/src/Altinn.ApiClients.Maskinporten/Services/MemoryTokenCacheProvider.cs
+++ b/src/Altinn.ApiClients.Maskinporten/Services/MemoryTokenCacheProvider.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Threading.Tasks;
+using Altinn.ApiClients.Maskinporten.Interfaces;
+using Altinn.ApiClients.Maskinporten.Models;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Altinn.ApiClients.Maskinporten.Services
+{
+    public class MemoryTokenCacheProvider : ITokenCacheProvider
+    {
+        private readonly IMemoryCache _memoryCache;
+
+        public MemoryTokenCacheProvider(IMemoryCache memoryCache)
+        {
+            _memoryCache = memoryCache;
+        }
+        public Task<(bool success, TokenResponse result)> TryGetToken(string key)
+        {
+            bool success = _memoryCache.TryGetValue(key, out TokenResponse result);
+            return Task.FromResult((success, result));
+        }
+
+        public async Task Set(string key, TokenResponse value, TimeSpan timeToLive)
+        {
+            MemoryCacheEntryOptions cacheEntryOptions = new MemoryCacheEntryOptions()
+            {
+                Priority = CacheItemPriority.High,
+            };
+
+            cacheEntryOptions.SetAbsoluteExpiration(timeToLive);
+            _memoryCache.Set(key, value, cacheEntryOptions);
+
+            await Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
Replaces default IMemoryCache-based implementation with `ITokenCacheProvider`, allowing for various caching backends (file, distributed) suitable for different needs.

Adds as an option a file-based token cache provider (`FileTokenCacheProvider`) that can be used instead of the default memory based implementation, suitable for CLI applications where tokens should be reused across multiple invocations.