### PR TITLE
Add the ExchangeToAltinnToken method in MaskinportenService to the IMaskinportenService interface

### DIFF
--- a/src/Altinn.ApiClients.Maskinporten/Interfaces/IMaskinportenService.cs
+++ b/src/Altinn.ApiClients.Maskinporten/Interfaces/IMaskinportenService.cs
@@ -26,5 +26,10 @@ namespace Altinn.ApiClients.Maskinporten.Interfaces
         /// Generates a access token based on supplied definition containing settings and secrets.
         /// </summary>
         Task<TokenResponse> GetToken(IClientDefinition clientDefinition, bool disableCaching = false);
+
+        /// <summary>
+        /// Exchanges a Maskinporten access token to a Altinn token.
+        /// </summary>
+        Task<TokenResponse> ExchangeToAltinnToken(TokenResponse tokenResponse, string environment, string userName = null, string password = null, bool disableCaching = false, bool isTestOrg = false);
     }
 }


### PR DESCRIPTION
This adds the ExchangeToAltinnToken method to the IMaskinportenInterface, so you don't have to take a dependency on the implementation instead of the interface since it wasn't included in the first place. This also helps mocking out the dependency in integration tests.

