### PR TITLE
Add support for configuring token exchange environment (fixes #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,13 @@ If you require an Altinn Exchanged token for the TTD organisation, this is suppo
 "UseAltinnTestOrg": true
 ```
 
+The environment for the token exchange is by default derived from the Maskinporten environment. This can also be explicitly configured:
+
+```jsonc
+// Valid values: at21, at22, at23, at24, tt02, prod
+"TokenExchangeEnvironment": "at24"
+```
+
 These settings can also be supplied by providing a delegate like:
 
 ```c#
@@ -222,6 +229,7 @@ services.AddMaskinportenHttpClient<SettingsJwkClientDefinition, MyMaskinportenHt
 {
     clientDefinition.ClientSettings.ExhangeToAltinnToken = true;
     clientDefinition.ClientSettings.UseAltinnTestOrg = true;
+    clientDefinition.ClientSettings.TokenExchangeEnvironment = "at24";
 });
 ```
 

--- a/src/Altinn.ApiClients.Maskinporten/Config/MaskinportenSettings.cs
+++ b/src/Altinn.ApiClients.Maskinporten/Config/MaskinportenSettings.cs
@@ -20,7 +20,7 @@ namespace Altinn.ApiClients.Maskinporten.Config
         public string Resource { get; set; }
 
         /// <summary>
-        /// The Maskinporten environment. Valid values are ver1, ver2 or prod
+        /// The Maskinporten environment. Valid values are ver1, ver2, test or prod
         /// </summary>
         public string Environment { get; set; }
 
@@ -68,6 +68,11 @@ namespace Altinn.ApiClients.Maskinporten.Config
         /// Optional. Enables Altinn token exchange without enterprise user authentication. Ignored if EnterpriseUserName/Password is supplied (which implies token exchange).
         /// </summary>
         public bool? ExhangeToAltinnToken { get; set; }
+
+        /// <summary>
+        /// Optional. The Altinn Token Exchange environment. Valid values are prod, tt02, at21, at22, at23, at24. Default: derive from 'Environment'
+        /// </summary>
+        public string TokenExchangeEnvironment { get; set; }
 
         /// <summary>
         /// Optional. Enables the DigDir token to be exchanged into a Altinn token for the test organisation.


### PR DESCRIPTION
`ExchangeToAltinnToken` will by default derive token exchange endpoint from Maskinporten environment. This change adds a separate optional configuration setting, `TokenExchangeEnvironment` which can be supplied with a environment identifier to set this explicitly. This allows for the use of AT-environments for token exchange and enterprise user authentication.

## Related Issue(s)
- #7
