### PR TITLE
fix: Add yt01 token exchange, revert .NET 8 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,12 +34,6 @@ bld/
 [Ll]og/
 [Ll]ogs/
 
-# JetBrains IDEs
-.idea/
-
-#MacOS
-.DS_Store
-
 # Visual Studio 2015/2017 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# JetBrains IDEs
+.idea/
+
+# macOS
+.DS_Store
+
 # Secrets
 Certs/
 

--- a/samples/SampleWebApp/SampleWebApp.csproj
+++ b/samples/SampleWebApp/SampleWebApp.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
+    <PackageReference Include="Azure.Identity" Version="1.10.2" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -18,5 +18,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+
 
 </Project>

--- a/src/Altinn.ApiClients.Maskinporten/Altinn.ApiClients.Maskinporten.csproj
+++ b/src/Altinn.ApiClients.Maskinporten/Altinn.ApiClients.Maskinporten.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -14,17 +14,17 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Altinn/altinn-apiclient-maskinporten</RepositoryUrl>
   </PropertyGroup>
-
+   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.0.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.0.2" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Altinn.ApiClients.Maskinporten/Services/MaskinportenService.cs
+++ b/src/Altinn.ApiClients.Maskinporten/Services/MaskinportenService.cs
@@ -374,6 +374,7 @@ namespace Altinn.ApiClients.Maskinporten.Services
                 "at22" => "https://platform.at22.altinn.cloud/authentication/api/v1/exchange/maskinporten",
                 "at23" => "https://platform.at23.altinn.cloud/authentication/api/v1/exchange/maskinporten",
                 "at24" => "https://platform.at24.altinn.cloud/authentication/api/v1/exchange/maskinporten",
+                "yt01" => "https://platform.yt01.altinn.cloud/authentication/api/v1/exchange/maskinporten",
                 // Supported for backward compatibility
                 "ver1" => "https://platform.tt02.altinn.no/authentication/api/v1/exchange/maskinporten",
                 "ver2" => "https://platform.tt02.altinn.no/authentication/api/v1/exchange/maskinporten",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added yt01 as a token exchange

Revert .NET 8 upgrade

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
