### PR TITLE
Pin actions/checkout to commit SHA

### DIFF
--- a/.github/workflows/ci-nuget.yml
+++ b/.github/workflows/ci-nuget.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 15
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Set VERSION variable from latest tag (if existing) plus date and commit
       run: | 


### PR DESCRIPTION
## Summary
- Pin `actions/checkout@v4` to its full commit SHA (`34e114876b0b11c390a56381ad16ebd13914f8d5`, v4.3.1) in `ci-nuget.yml`
- Supply chain hardening: prevents a compromised or force-pushed tag from silently changing the action code that runs in CI

## Related Issue
- https://github.com/Altinn/dialogporten/issues/3697

## Notes
- `release-nuget.yml` already had checkout pinned to a SHA (`v6.0.1`), so no change was needed there
- No functional changes