### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci-nuget.yml
+++ b/.github/workflows/ci-nuget.yml
@@ -5,9 +5,13 @@ on:
     branches:
     - main
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 15
     steps:
     - name: Checkout
@@ -43,6 +47,8 @@ jobs:
   push:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
 
     - name: Download artifact

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -6,9 +6,14 @@ on:
   push:
     tags:
     - "v[0-9]+.[0-9]+.[0-9]+.*"
+
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 15
     outputs:
       version: ${{ steps.set_version.outputs.version }}
@@ -46,6 +51,7 @@ jobs:
   push-to-nuget:
     needs: build
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
     - name: Download artifact
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -58,6 +64,8 @@ jobs:
   push-to-github:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
     - name: Download artifact
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0


### PR DESCRIPTION
## Summary
- Adds top-level `permissions: {}` to both `ci-nuget.yml` and `release-nuget.yml` to restrict default GITHUB_TOKEN permissions
- Grants least-privilege permissions at the job level: `contents: read` for build/checkout jobs, `packages: write` for GitHub Packages push jobs, and empty `permissions: {}` for the nuget.org push job (uses API key, not GITHUB_TOKEN)
- Fixes all 5 open CodeQL "Workflow does not contain permissions" (Medium) warnings

## Test plan
- [ ] Verify CI workflow runs successfully on push to main
- [ ] Verify release workflow can still push packages to both nuget.org and GitHub Packages