### PR TITLE
fix: changed regex to work with github and yaml

### DIFF
--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-    - "v[0-9]+\.[0-9]+\.[0-9]+(\-.*)?"
+      - 'v[0-9]+\.[0-9]+\.[0-9]+(\-.*)?'
 
 permissions: {}
 


### PR DESCRIPTION
## Description
"\\." is not allowed in YAML when using double quotes, change to singel quotes. 
